### PR TITLE
Stack corruption fixed

### DIFF
--- a/recorder/main.c
+++ b/recorder/main.c
@@ -61,7 +61,7 @@ void test_rx(int mode)
     int result = 0;
     char lib_version[32];
     char drv_version[32];
-    char serials[256];
+    char serials[256] = {0};
 
     int index = 0;
 


### PR DESCRIPTION
There is stack corruption due to C string functions operating on uninitialized data. Filling the array with 0s solves the problem.